### PR TITLE
add pcd all features and fhir mapping config fixes 

### DIFF
--- a/config/ground-truth-yaml-files/all_features_version_10.1_no_visit_variant_pcd.yml
+++ b/config/ground-truth-yaml-files/all_features_version_10.1_no_visit_variant_pcd.yml
@@ -1,4 +1,14 @@
 patient:
+  study_period:
+    categories:
+    - biolink:PhenotypicFeature
+    enum:
+    type: string
+  Active_In_Study_Period:
+    categories:
+    - biolink:PhenotypicFeature
+    enum:
+    type: string  
   A1C:
     categories:
     - biolink:PhenotypicFeature
@@ -2212,6 +2222,7 @@ patient:
     name_lookup:
     - limit: 1
       search_term: methylprednisone
+    type: string
   MiddleEarDiseaseDx:
     categories:
     - biolink:Disease

--- a/config/ground-truth-yaml-files/icees_features_FHIR_mappings_pcd.yaml
+++ b/config/ground-truth-yaml-files/icees_features_FHIR_mappings_pcd.yaml
@@ -1089,7 +1089,7 @@ FHIR:
       system: http://www.nlm.nih.gov/research/umls/rxnorm 
     - code: '203217'
       system: http://www.nlm.nih.gov/research/umls/rxnorm 
-  MedroxyprogresteroneRx:
+  MedroxyprogesteroneRx:
     MedicationRequest:
     - code: '6691'
       system: http://www.nlm.nih.gov/research/umls/rxnorm 
@@ -1969,7 +1969,7 @@ FHIR:
       system: http://www.nlm.nih.gov/research/umls/rxnorm
     - code: '1664988'
       system: http://www.nlm.nih.gov/research/umls/rxnorm
-  AzythromycinRx:
+  AzithromycinRx:
     MedicationRequest:
     - code: '18631'
       system: http://www.nlm.nih.gov/research/umls/rxnorm

--- a/data_processing/compare_feature_names.py
+++ b/data_processing/compare_feature_names.py
@@ -1,0 +1,26 @@
+import argparse
+import yaml
+
+parser = argparse.ArgumentParser(description='Process arguments.')
+parser.add_argument('input_feature_yml', type=str,
+                    help='input all features yaml file')
+parser.add_argument('input_fhir_mapping_yaml', type=str,
+                    help='input fhir mapping yaml file')
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+    input_feature_yml = args.input_feature_yml
+    input_fhir_mapping_yml = args.input_fhir_mapping_yaml
+
+    with open(input_feature_yml, 'r') as f:
+        features_dict = yaml.safe_load(f)
+
+    with open(input_fhir_mapping_yml, 'r') as f:
+        fhir_dict = yaml.safe_load(f)
+
+    feature_names = list(features_dict['patient'].keys())
+    fhir_feature_names = list(fhir_dict['FHIR'].keys())
+    print(f'feature names in all features but not in FHIR mapping: '
+          f'{set(feature_names).difference(set(fhir_feature_names))}')
+    print(f'feature names in FHIR mapping but not in all features: '
+          f'{set(fhir_feature_names).difference(set(feature_names))}')


### PR DESCRIPTION
adding pcd all features and fhir mapping config fixes and a data processing script to compare feature names between config files. @karafecho These config fixes are needed to get sqlite database created successfully for the latest PCD dataset. See if it looks good to be merged.