### PR TITLE
Remove duplicate feature that also had a yaml error

### DIFF
--- a/config/ground-truth-yaml-files/all_features_version_10.1_no_visit_variant_pcd.yml
+++ b/config/ground-truth-yaml-files/all_features_version_10.1_no_visit_variant_pcd.yml
@@ -2014,16 +2014,6 @@ patient:
     - biolink:EnvironmentalExposure
     maximum: 5
     minimum: 1
-    name_lookup: exposure
-    - limit: 10
-      search_term: ozone exposure
-    type: integer
-  MaxDailyOzoneExposure:
-    categories:
-    - biolink:ChemicalEntity
-    - biolink:EnvironmentalExposure
-    maximum: 5
-    minimum: 1
     name_lookup:
     - limit: 10
       search_term: ozone exposure


### PR DESCRIPTION
My python yaml parser found that this line: https://github.com/ExposuresProvider/icees-api-config/blob/master/config/ground-truth-yaml-files/all_features_version_10.1_no_visit_variant_pcd.yml#L2017 had `exposure` on the same line as name_lookup and was invalid yaml. I also noticed that that feature was duplicated. So I removed the duplicate that had the error.